### PR TITLE
26-Add new coordinator roles to base data

### DIFF
--- a/src/main/java/org/kumoricon/site/utility/loadbasedata/LoadBaseDataPresenter.java
+++ b/src/main/java/org/kumoricon/site/utility/loadbasedata/LoadBaseDataPresenter.java
@@ -134,6 +134,18 @@ public class LoadBaseDataPresenter {
                                                "print_badge", "attendee_edit", "attendee_add_note",
                                                "reprint_badge", "view_staff_report",
                                                "view_check_in_by_hour_report", "view_check_in_by_badge_report"});
+        roles.put("Coordinator - VIP Badges", new String[] {"at_con_registration", "pre_reg_check_in",
+                                                            "attendee_search", "print_badge", "attendee_edit",
+                                                            "attendee_add_note", "reprint_badge", "view_staff_report",
+                                                            "view_check_in_by_hour_report",
+                                                            "view_check_in_by_badge_report", "badge_type_vip"});
+        roles.put("Coordinator - Other Badges", new String[] {"at_con_registration", "pre_reg_check_in",
+                                                              "attendee_search", "print_badge", "attendee_edit",
+                                                              "attendee_add_note", "reprint_badge", "view_staff_report",
+                                                              "view_check_in_by_hour_report",
+                                                              "view_check_in_by_badge_report", "badge_type_artist",
+                                                              "badge_type_exhibitor", "badge_type_guest",
+                                                              "badge_type_panelist", "badge_type_industry"});
         roles.put("Manager", new String[] {"at_con_registration", "pre_reg_check_in", "attendee_search",
                 "print_badge", "attendee_edit", "attendee_add_note",
                 "badge_type_vip", "badge_type_press", "badge_type_artist", "badge_type_exhibitor", "badge_type_guest",


### PR DESCRIPTION
Added roles "Coordinator - VIP Badges" and "Coordinator - Other Badges", along with their associated rights, to the Load Base Data action. Tested and it seems to work fine.