### PR TITLE
Sort users in view. Fixes #47

### DIFF
--- a/src/main/java/org/kumoricon/site/user/UserPresenter.java
+++ b/src/main/java/org/kumoricon/site/user/UserPresenter.java
@@ -8,6 +8,7 @@ import org.kumoricon.model.user.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
@@ -65,7 +66,7 @@ public class UserPresenter {
 
     public void showUserList(UserView view) {
         log.info("{} viewed user list", view.getCurrentUsername());
-        List<User> users = userRepository.findAll();
+        List<User> users = userRepository.findAll(new Sort(Sort.Direction.ASC, "username"));
         view.afterSuccessfulFetch(users);
     }
 


### PR DESCRIPTION
Note: sort only happens explicitly in User Presenter. If for some reason we decided we want the sort to take place in all cases of UserRepository.findAll(), an alternative approach is given in the accepted answer at http://stackoverflow.com/questions/29031028/change-default-sort-order-for-spring-data-findall-method