### PR TITLE
Add Report Printer Option

### DIFF
--- a/src/main/java/org/kumoricon/service/print/BadgePrintService.java
+++ b/src/main/java/org/kumoricon/service/print/BadgePrintService.java
@@ -45,10 +45,11 @@ public class BadgePrintService extends PrintService {
             // will be printed double sided if the first attendee is staff, otherwise they
             // will all be printed single sided.
             boolean setDuplexOn = false;
+            boolean isReport = false;
             if (BadgeType.STAFF.equals(attendees.get(0).getBadge().getBadgeType())) {
                 setDuplexOn = true;
             }
-            printDocument(badgePrintFormatter.getStream(), printerName, setDuplexOn);
+            printDocument(badgePrintFormatter.getStream(), printerName, setDuplexOn, isReport);
             return String.format("Printed %s badges to %s.",
                     attendees.size(),
                     printerName);

--- a/src/main/java/org/kumoricon/service/print/ReportPrintService.java
+++ b/src/main/java/org/kumoricon/service/print/ReportPrintService.java
@@ -16,12 +16,13 @@ public class ReportPrintService extends PrintService {
      * @return String Result message
      */
     public String printReport(String reportText, String clientIPAddress) {
+        boolean isReport = true;
         if (enablePrintingFromServer != null && enablePrintingFromServer) {
             Computer client = computerService.findComputerByIP(clientIPAddress);
             ReportPrintFormatter formatter =
                     new ReportPrintFormatter(reportText, client.getxOffset(), client.getyOffset());
             try {
-                printDocument(formatter.getStream(), client.getPrinterName(), false);
+                printDocument(formatter.getStream(), client.getPrinterName(), false, isReport);
                 return "Printed to " + client.getPrinterName();
             } catch (PrintException e) {
                 log.error(String.format("Error printing report for %s: %s",

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -61,6 +61,10 @@ info.build.buildDate=@maven.build.timestamp@
 # If true, print badges via printers installed locally on server.
 kumoreg.printing.enablePrintingFromServer=true
 
+# Designate a printer as the report printer
+#kumoreg.printing.reportPrinter=Hewlett-Packard-HP-LaserJet-200-color-M251nw
+kumoreg.printing.reportPrinter=
+
 # Which badge format to use? Valid formats are "lite" and "full"
 kumoreg.printing.badgeFormat=full
 


### PR DESCRIPTION
Adds the ability to redirect reports being printed to a printer specified in application.properties. Files changed are PrintService.java, BadgePrintService.java, ReportPrintService.java, and application.properties.

NOTE: the relevant changes are in c36743a, which is named incorrectly. I tried to squash all of these commits and rename that commit but was unable to have it show up properly on GitHub.